### PR TITLE
Fixed LOADIN and STOREIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ PRINT i
 ```
 
 **Notes:**  
-- `LOADIN` and `STOREIN` are used as follows: `LOADIN ACC IN1`
+- `LOADIN` and `STOREIN` are used as follows:
+`LOADIN j i` has the effect of `ACC := M(INj + i)`
+where `j` needs to be `0` or `1` and i can be any integer literal.
+
+
 - `JUMPC c i` is defined slightly different than in the lecture. Simply pass the conditional as the first argument c.
 - `PRINT i` is not defined in the lecture. It can be used to print the value of S[i] from memory to the console.
 

--- a/reti.py
+++ b/reti.py
@@ -55,13 +55,13 @@ def SUBI(i):
 
 def LOADIN(j, i):
     global acc, pc
-    acc = s[ind[j], i]
+    acc = s[ind[j] + i]
     pc += 1
 
 
 def STOREIN(j, i):
     global pc
-    s[ind[j], i] = acc
+    s[ind[j] + i] = acc
     pc += 1
 
 


### PR DESCRIPTION
I updated the README.md, to clarify the usage of the `LOADIN` and `STOREIN`
commands and fixed there behaviour:

It used to throw no error when used but also did not store/load the values correctly.
Now it accesses the Memory with the same indices as `LOAD` and `STORE` would, but with an offset of IN1 or IN2.
Now the implementation follows the documented behaviour.