### PR TITLE
inline comments + minor fixes

### DIFF
--- a/examples/multiply.txt
+++ b/examples/multiply.txt
@@ -2,7 +2,7 @@
 # Multiplies S[0] with S[1]
 
 # Load x = 5 into S[0]
-LOADI 5 
+LOADI 5
 STORE 0
 
 # Load y = 4 into S[1]

--- a/examples/multiply.txt
+++ b/examples/multiply.txt
@@ -2,7 +2,7 @@
 # Multiplies S[0] with S[1]
 
 # Load x = 5 into S[0]
-LOADI 5
+LOADI 5 
 STORE 0
 
 # Load y = 4 into S[1]

--- a/examples/switch.txt
+++ b/examples/switch.txt
@@ -1,10 +1,10 @@
 # Kapitel 1 der Vorlesung
 # Switches S[0] and S[1] in memory, using S[2] as a temporary storage
 
-LOADI 20 # arbitrary example value
+LOADI 20
 STORE 0
 
-LOADI 40 # arbitrary example value
+LOADI 40
 STORE 1
 
 LOAD 0

--- a/examples/switch.txt
+++ b/examples/switch.txt
@@ -1,10 +1,10 @@
 # Kapitel 1 der Vorlesung
 # Switches S[0] and S[1] in memory, using S[2] as a temporary storage
 
-LOADI 20
+LOADI 20 # arbitrary example value
 STORE 0
 
-LOADI 40
+LOADI 40 # arbitrary example value
 STORE 1
 
 LOAD 0

--- a/reti.py
+++ b/reti.py
@@ -140,14 +140,14 @@ def should_jump(conditional):
     if conditional == '>=':
         return acc >= 0
 
-    return False
+    raise NotImplementedError(f'conditional jump JUMPC {conditional} does not exist')
 
 
 def read_instructions():
-    path = sys.argv[1] if len(sys.argv) > 1 else 'multiply.txt'
+    path = sys.argv[1] if len(sys.argv) > 1 else 'examples/multiply.txt'
     file = open(path, 'r')
     lines = file.readlines()
-    return [line.strip().split(" ") for line in lines
+    return [line.split("#")[0].strip().split(" ") for line in lines
             if not line.startswith('#') and line.strip() != ""]
 
 

--- a/reti.py
+++ b/reti.py
@@ -140,7 +140,7 @@ def should_jump(conditional):
     if conditional == '>=':
         return acc >= 0
 
-    raise NotImplementedError(f'conditional jump JUMPC {conditional} does not exist')
+    raise NotImplementedError(f'conditional jump JUMPC {conditional} using invalid condition {conditional}')
 
 
 def read_instructions():


### PR DESCRIPTION
- added support for inline comments, which I thought could make keeping track of exact jump distances less of a hassle
- had some trouble trying to figure out why a program doesn't work only to find out it incorrectly typoed "JUMPC =" as "JUMPC ==", so the emulator now raises an exception if an invalid comparator is encountered
- fixed path for calling the default multiply program (now correctly calls 'examples/multiply.txt' instead of 'multiply.txt')